### PR TITLE
Remove <pre> tags from text used for language detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@
 
 source "https://rubygems.org"
 
+gem "nokogiri"
+
 group :development do
   gem "rubocop-discourse"
   gem "syntax_tree"

--- a/services/discourse_translator/base.rb
+++ b/services/discourse_translator/base.rb
@@ -56,6 +56,12 @@ module DiscourseTranslator
       when "Topic"
         text = topic_or_post.title
       end
+
+      # Remove preformatted text (usually code)
+      @html_doc = Nokogiri::HTML::DocumentFragment.parse(text)
+      @html_doc.css("pre").unlink
+      text = @html_doc.to_s()
+
       ActionView::Base.full_sanitizer.sanitize(text)
     end
 


### PR DESCRIPTION
These are usually code so they can cause misdetection.